### PR TITLE
Don't use cli_repl anymore

### DIFF
--- a/packages/interactive/lib/src/reader.dart
+++ b/packages/interactive/lib/src/reader.dart
@@ -1,18 +1,20 @@
-import 'package:cli_repl/cli_repl.dart';
+import "dart:io";
+import "Dart:convert";
+
 import 'package:interactive/src/main.dart';
 
-Reader createReader() => Repl(
-      prompt: '>>> ',
-      continuation: '... ',
-      validator: replValidator,
-    ).run;
+Reader createReader() => stdin.transform(systemEncoding.decoder).transform(const LineSplitter());
+
+
+
+
 
 const _leftBrackets = ['{', '[', '('];
 const _rightToLeftBracketMap = {'}': '{', ']': '[', ')': '('};
 
 bool replValidator(String text) {
   // when having a full blank line, forcefully say yes
-  if (text.split('\n').contains('')) return true;
+  if (text.isEmpty) return true;
 
   final stack = <String>[];
   for (var i = 0; i < text.length; ++i) {


### PR DESCRIPTION
It not only forces you to use weird keystrokes instead of for example backspace, up / down ETC, but also silently breaks the normal ones in one way or another. If you ever noticed that pressing backspace would invalidate the line of code you're working on, this is why.

Also made line reading async so our isolate message handlers can run whenever instead of waiting for readLineSync() to finish.