### PR TITLE
dart 3.3.0+, analyzer 7+

### DIFF
--- a/packages/interactive/pubspec.yaml
+++ b/packages/interactive/pubspec.yaml
@@ -4,15 +4,16 @@ version: 1.4.0
 repository: https://github.com/fzyzcjy/flutter_interactive
 
 environment:
-  sdk: ">=2.18.0 <3.0.0"
+  sdk: ">=3.3.0 <4.0.0"
 
 dependencies:
-  analyzer: ">=5.0.0 <=5.2.0"
+  analyzer: ^7.0.0
   args: ^2.3.1
   cli_repl: ^0.2.3
   collection: ^1.17.0
   logging: ^1.1.0
   path: ^1.8.2
+  pub_semver: ^2.1.5
   vm_service: ">=9.0.0 <12.0.0"
 
 dev_dependencies:


### PR DESCRIPTION
There may be a possibility to support a wider array of dart versions by not upgrading _as_ high and I'm open to it if needed.

I fixed the errors as I encountered them so it is as minimal as I could make it without much extra effort. The interactive REPL works fine for me with a couple of simple statements!